### PR TITLE
update sample consistency checks

### DIFF
--- a/ssm/arhmm/base.py
+++ b/ssm/arhmm/base.py
@@ -5,11 +5,12 @@ import jax.numpy as np
 import jax.random as jr
 from jax import vmap, lax
 from jax.tree_util import register_pytree_node_class
+from functools import partial
 
 import tensorflow_probability.substrates.jax as tfp
 
 from ssm.hmm.base import HMM
-from ssm.utils import tree_get, tree_concatenate, auto_batch
+from ssm.utils import tree_get, tree_concatenate, auto_batch, tree_map
 
 @register_pytree_node_class
 class AutoregressiveHMM(HMM):
@@ -174,8 +175,9 @@ class AutoregressiveHMM(HMM):
                                               (history, initial_state), 
                                               (keys, tree_get(covariates, slice(1, None))))
             
-            states = np.concatenate((np.expand_dims(initial_state, axis=0), states))
-            emissions = np.concatenate((np.expand_dims(initial_emission, axis=0), emissions))
+            expand_dims_fn = partial(np.expand_dims, axis=0)
+            states = tree_concatenate(tree_map(expand_dims_fn, initial_state), states)
+            emissions = tree_concatenate(tree_map(expand_dims_fn, initial_emission), emissions)
             
             return states, emissions
 

--- a/ssm/inference/laplace_em.py
+++ b/ssm/inference/laplace_em.py
@@ -127,6 +127,10 @@ def _compute_laplace_precision_blocks(model, states, data):
     return J_diag, J_lower_diag
 
 
+# recognition network :: model, data --> approximate posterior
+
+
+
 def laplace_approximation(model, data, initial_states, laplace_mode_fit_method="L-BFGS", num_laplace_mode_iters=10):
     """
     Laplace approximation to the posterior distribution for state space models

--- a/ssm/lds/emissions.py
+++ b/ssm/lds/emissions.py
@@ -229,7 +229,7 @@ class PoissonEmissions(Emissions):
     @property
     def bias(self):
         return self._distribution.bias
-
+    
     def distribution(self, state, covariates=None, metadata=None):
         if covariates is not None:
             return self._distribution.predict(np.concatenate([state, covariates]))

--- a/tests/arhmm/test_arhmm.py
+++ b/tests/arhmm/test_arhmm.py
@@ -27,14 +27,14 @@ def test_gaussian_arhmm_sample():
     
 def test_gaussian_arhmm_sample_is_consistent():
     # sampled from ARHMM previously 
-    true_states = np.array([[0, 2, 2],
+    true_states = np.array([[0, 2, 1],
                             [0, 0, 0]], dtype=np.int32)
-    true_data = np.array([[[ 1.1885295 ,  0.55225945],
-                           [ 1.3390907 ,  0.8323249 ],
-                           [ 2.7013097 ,  1.469697  ]],
-                          [[-1.3038868 , -1.4337387 ],
-                           [-2.3088303 , -0.5458503 ],
-                           [ 0.1273387 , -1.296866  ]]], dtype=np.float32)
+    true_data = np.array([[[-1.0043284 ,  0.4558727 ],
+                           [ 4.4478188 , -1.7673836 ],
+                           [-9.901798  ,  0.79967743]],
+                          [[-0.4406956 ,  0.06618765],
+                           [-1.059847  ,  0.6474356 ],
+                           [ 2.0843577 ,  0.72555685]]], dtype=np.float32)
     
     rng1, rng2 = jr.split(SEED, 2)
     arhmm = GaussianARHMM(3, 2, 1, seed=rng1)

--- a/tests/arhmm/test_arhmm.py
+++ b/tests/arhmm/test_arhmm.py
@@ -40,7 +40,7 @@ def test_gaussian_arhmm_sample_is_consistent():
     arhmm = GaussianARHMM(3, 2, 1, seed=rng1)
     states, data = arhmm.sample(rng2, num_steps=3, num_samples=2)
     assert np.all(true_states == states)
-    assert np.allclose(true_data, data)
+    assert np.allclose(true_data, data, atol=1e-5)
     
 def test_gaussian_arhmm_em_fit():
     rng1, rng2, rng3 = jr.split(SEED, 3)

--- a/tests/hmm/test_hmm.py
+++ b/tests/hmm/test_hmm.py
@@ -36,14 +36,14 @@ def test_gaussian_hmm_sample():
 def test_gaussian_hmm_sample_is_consistent():
     rng1, rng2 = jr.split(SEED, 2)
     
-    true_states = np.array([[0, 2, 2],
-                            [0, 0, 0]], dtype=np.int32)
-    true_data = np.array([[[ 1.901474 ,  0.3903318],
-                           [ 1.4439511,  1.0113559],
-                           [ 2.636291 ,  1.7115304]],
-                          [[-0.5909422, -1.5956663],
-                           [-1.248173 , -0.5830741],
-                           [ 0.7204445, -1.533948 ]]], dtype=np.float32)
+    true_states = np.array([[0, 2, 0],
+                            [0, 0, 2]], dtype=np.int32)
+    true_data = np.array([[[-0.29138386,  0.29394504],
+                           [ 0.4951557 ,  1.1221184 ],
+                           [ 0.19978702, -0.15766774]],
+                          [[ 0.27224892, -0.09574001],
+                           [-1.8726401 , -2.213043  ],
+                           [ 0.350825  ,  1.7823567 ]]], dtype=np.float32)
     rng1, rng2 = jr.split(SEED, 2)
     hmm = GaussianHMM(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
@@ -60,14 +60,14 @@ def test_poisson_hmm_sample():
 def test_poisson_hmm_sample_is_consistent():
     rng1, rng2 = jr.split(SEED, 2)
     
-    true_states = np.array([[0, 2, 2],
-                            [0, 0, 0]], dtype=np.int32)
-    true_data = np.array([[[2., 3.],
-                           [1., 5.],
-                           [3., 4.]],
-                          [[2., 4.],
-                           [0., 5.],
-                           [4., 4.]]], dtype=np.float32)
+    true_states = np.array([[0, 2, 0],
+                            [0, 0, 2]], dtype=np.int32)
+    true_data = np.array([[[2., 5.],
+                           [3., 7.],
+                           [2., 2.]],
+                          [[2., 1.],
+                           [1., 2.],
+                           [4., 3.]]], dtype=np.float32)
     rng1, rng2 = jr.split(SEED, 2)
     hmm = PoissonHMM(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
@@ -84,14 +84,14 @@ def test_bernoulli_hmm_sample():
 def test_bernoulli_hmm_sample_is_consistent():
     rng1, rng2 = jr.split(SEED, 2)
     
-    true_states = np.array([[0, 2, 2],
-                            [0, 0, 0]], dtype=np.int32)
+    true_states = np.array([[0, 2, 0],
+                            [0, 0, 2]], dtype=np.int32)
     true_data = np.array([[[1, 0],
                            [1, 1],
-                           [0, 0]],
-                          [[1, 1],
+                           [1, 0]],
+                          [[1, 0],
                            [1, 1],
-                           [1, 1]]], dtype=np.int32)
+                           [1, 0]]], dtype=np.int32)
     rng1, rng2 = jr.split(SEED, 2)
     hmm = BernoulliHMM(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)

--- a/tests/hmm/test_hmm.py
+++ b/tests/hmm/test_hmm.py
@@ -48,7 +48,7 @@ def test_gaussian_hmm_sample_is_consistent():
     hmm = GaussianHMM(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
     assert np.all(true_states == states)
-    assert np.allclose(true_data, data)
+    assert np.allclose(true_data, data, atol=1e-5)
     
 def test_poisson_hmm_sample():
     rng1, rng2 = jr.split(SEED, 2)
@@ -72,7 +72,7 @@ def test_poisson_hmm_sample_is_consistent():
     hmm = PoissonHMM(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
     assert np.all(true_states == states)
-    assert np.allclose(true_data, data)
+    assert np.allclose(true_data, data, atol=1e-5)
     
 def test_bernoulli_hmm_sample():
     rng1, rng2 = jr.split(SEED, 2)
@@ -96,7 +96,7 @@ def test_bernoulli_hmm_sample_is_consistent():
     hmm = BernoulliHMM(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
     assert np.all(true_states == states)
-    assert np.allclose(true_data, data)
+    assert np.allclose(true_data, data, atol=1e-5)
     
 def test_gaussian_hmm_em_fit():
     rng1, rng2, rng3 = jr.split(SEED, 3)

--- a/tests/lds/test_lds.py
+++ b/tests/lds/test_lds.py
@@ -4,6 +4,8 @@ import jax.random as jr
 import jax.numpy as np
 from jax import jit
 
+import numpy as onp
+
 from ssm.lds import GaussianLDS, PoissonLDS
 
 SEED = jr.PRNGKey(0)
@@ -33,22 +35,22 @@ def test_gaussian_lds_sample_is_consistent():
     rng1, rng2 = jr.split(SEED, 2)
     
     true_states = np.array([[[ 2.0503902 , -0.98077524, -1.389261  ],
-                             [ 2.143722  , -1.0683461 , -1.1490295 ],
-                             [ 2.21696   , -1.1373025 , -0.9108291 ]],
+                             [ 2.1278157 , -1.0894692 , -1.1714737 ],
+                             [ 2.2172518 , -1.1573169 , -0.93505853]],
                             [[ 0.17471106, -0.05582879, -1.9695592 ],
-                             [ 0.24238327, -0.34164798, -1.9394323 ],
-                             [ 0.31522033, -0.63146836, -1.8712306 ]]], dtype=np.float32)
-    true_data = np.array([[[ 4.185537  , -0.3276755 ],
-                           [ 3.05506   , -0.72648746],
-                           [ 4.175408  , -0.05829722]],
-                          [[ 0.12157202, -1.9061788 ],
-                           [-0.56306684, -1.0952222 ],
-                           [ 1.3611842 , -2.24853   ]]], dtype=np.float32)
+                             [ 0.24917215, -0.34881595, -1.9439837 ],
+                             [ 0.33026809, -0.6336352 , -1.8497025 ]]], dtype=np.float32)
+    true_data = np.array([[[ 1.9926789 , -0.42406225],
+                           [ 2.0938962 , -0.6344335 ],
+                           [ 2.364299  , -0.9663689 ]],
+                          [[ 0.984763  , -0.40625238],
+                           [-1.1792403 , -2.729756  ],
+                           [ 0.37870926,  0.0921855 ]]], dtype=np.float32)
     rng1, rng2 = jr.split(SEED, 2)
     hmm = GaussianLDS(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
-    assert np.allclose(true_states, states)
-    assert np.allclose(true_data, data)
+    onp.testing.assert_allclose(true_states, states)
+    onp.testing.assert_allclose(true_data, data)
     
 def test_poisson_lds_sample():
     rng1, rng2 = jr.split(SEED, 2)
@@ -61,22 +63,21 @@ def test_poisson_lds_sample_is_consistent():
     rng1, rng2 = jr.split(SEED, 2)
     
     true_states = np.array([[[ 2.0503902 , -0.98077524, -1.389261  ],
-                             [ 2.143722  , -1.0683461 , -1.1490295 ],
-                             [ 2.21696   , -1.1373025 , -0.9108291 ]],
+                             [ 2.1278157 , -1.0894692 , -1.1714737 ],
+                             [ 2.2172518 , -1.1573169 , -0.93505853]],
                             [[ 0.17471106, -0.05582879, -1.9695592 ],
-                             [ 0.24238327, -0.34164798, -1.9394323 ],
-                             [ 0.31522033, -0.63146836, -1.8712306 ]]], dtype=np.float32)
-    true_data = np.array([[[17.,  0.],
-                           [12.,  0.],
-                           [15.,  0.]],
-                          [[ 4.,  2.],
-                           [ 1.,  0.],
-                           [ 5.,  1.]]], dtype=np.float32)
-    rng1, rng2 = jr.split(SEED, 2)
-    hmm = PoissonLDS(3, 2, seed=rng1)
-    states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
-    assert np.allclose(true_states, states)
-    assert np.allclose(true_data, data)
+                             [ 0.24917215, -0.34881595, -1.9439837 ],
+                             [ 0.33026809, -0.6336352 , -1.8497025 ]]], dtype=np.float32)
+    true_data = np.array([[[20.,  3.],
+                           [13.,  0.],
+                           [14.,  0.]],
+                          [[ 5.,  1.],
+                           [ 2.,  0.],
+                           [ 4.,  1.]]], dtype=np.float32)
+    lds = PoissonLDS(3, 2, seed=rng1)
+    states, data = lds.sample(rng2, num_steps=3, num_samples=2)
+    onp.testing.assert_allclose(true_states, states)
+    onp.testing.assert_allclose(true_data, data)
     
 def test_gaussian_lds_em_fit():
     rng1, rng2, rng3 = jr.split(SEED, 3)

--- a/tests/lds/test_lds.py
+++ b/tests/lds/test_lds.py
@@ -49,8 +49,8 @@ def test_gaussian_lds_sample_is_consistent():
     rng1, rng2 = jr.split(SEED, 2)
     hmm = GaussianLDS(3, 2, seed=rng1)
     states, data = hmm.sample(rng2, num_steps=3, num_samples=2)
-    onp.testing.assert_allclose(true_states, states)
-    onp.testing.assert_allclose(true_data, data)
+    onp.testing.assert_allclose(true_states, states, atol=1e-5)
+    onp.testing.assert_allclose(true_data, data, atol=1e-5)
     
 def test_poisson_lds_sample():
     rng1, rng2 = jr.split(SEED, 2)
@@ -76,8 +76,8 @@ def test_poisson_lds_sample_is_consistent():
                            [ 4.,  1.]]], dtype=np.float32)
     lds = PoissonLDS(3, 2, seed=rng1)
     states, data = lds.sample(rng2, num_steps=3, num_samples=2)
-    onp.testing.assert_allclose(true_states, states)
-    onp.testing.assert_allclose(true_data, data)
+    onp.testing.assert_allclose(true_states, states, atol=1e-5)
+    onp.testing.assert_allclose(true_data, data, atol=1e-5)
     
 def test_gaussian_lds_em_fit():
     rng1, rng2, rng3 = jr.split(SEED, 3)


### PR DESCRIPTION
The previous merge to fix the covariates sample off-by-one bug changed some of the ground truth for the sample consistency checks (seed splitting locations were changed). 

Fixing those tests here  -- although I should have done this before merging into main.